### PR TITLE
Added feature - returning money to customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,33 @@ mobilPay.handleGatewayResponse({
     // handle error case
   });
 ```
+
+### Cancel a payment
+In order to cancel a payment, you need a sessionId. `MobilPay.getSessionId()` method will return a promise that is resolved with an object that contains property sessionId:
+
+```javascript
+MobilPay.getSessionId({
+  username: 'mobilpay.username',
+  password: 'mobilpay.password'
+  })
+  .then(response => {
+    console.log(response); // { sessionId: 'unique user session identifier'}
+    const { sessionId } = response;
+  })
+  .catch(err => {
+    // handle error case
+    console.log(err)
+  })
+```
+
+Once you get the sessionId, you can store it in a (global) variable, and use it for each credit invoice request as below: 
+
+```javascript
+MobilPay.creditInvoice({
+  sessionId: sessionId,
+  orderId: '', // payment request id you want to credit
+  amount: 10
+})
+  .then(response => console.log(response))
+  .catch(err => console.log(err))
+```

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ mobilPay.handleGatewayResponse({
   });
 ```
 
-### Cancel a payment
+### Retrieve session id
 In order to cancel a payment, you need a sessionId. `MobilPay.getSessionId()` method will return a promise that is resolved with an object that contains property sessionId:
 
 ```javascript
@@ -148,13 +148,13 @@ MobilPay.getSessionId({
   })
 ```
 
-Once you get the sessionId, you can store it in a (global) variable, and use it for each credit invoice request as below: 
+### Cancel a payment
 
 ```javascript
 MobilPay.creditInvoice({
   sessionId: sessionId,
   orderId: '', // payment request id you want to credit
-  amount: 10
+  amount: 10 // must be equal or less than the initial amount
 })
   .then(response => console.log(response))
   .catch(err => console.log(err))

--- a/lib/MobilPay.js
+++ b/lib/MobilPay.js
@@ -23,6 +23,7 @@ const Promise = require('es6-promise').Promise;
 const xml2js = require('xml2js');
 const _ = require('lodash');
 const Notify = require('./Notify');
+const request = require('request');
 
 class MobilPay {
 
@@ -89,6 +90,126 @@ class MobilPay {
           reject(err);
         });
     });
+  }
+
+  createSoapRequest({ body }) {
+    return new Promise((resolve, reject) => {
+      const url = constants.REQUEST_ENDPOINTS.SOAP_API[this.config.sandbox ? constants.SANDBOX_MODE : constants.LIVE_MODE];
+      const builder = new xml2js.Builder();
+      const xml = builder.buildObject({
+        "soapenv:Envelope": {
+          "$": {
+            "xmlns:soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
+            "xmlns:pay": url
+          },
+          "soapenv:Body": body
+        }
+      })
+
+      const options = {
+        url: url,
+        body: xml,
+        headers: { 'Content-Type': 'text/xml' }
+      }
+
+      return request.post(options, (err, response, body) => {
+        if (err) {
+          return reject(err)
+        }
+
+        const parser = new xml2js.Parser({ explicitArray: false });
+        parser.parseString(body, (err, parsedXML) => {
+          if (err) {
+            return reject(err);
+          }
+
+          const soapBody = parsedXML['SOAP-ENV:Envelope']['SOAP-ENV:Body'];
+
+          // SOAP should response with statuses 2xx or 500 - https://www.w3.org/TR/2000/NOTE-SOAP-20000508/
+          if (response.statusCode === 500) {
+            const error = soapBody['SOAP-ENV:Fault']
+            return reject(error)
+          }
+          
+          return resolve(soapBody)
+        })
+      })
+    })
+  }
+
+  getSessionId({ username, password }) {
+    if (!username) {
+      throw new Error('username is required');
+    }
+
+    if (!password) {
+      throw new Error('password is required');
+    }
+
+    return new Promise((resolve, reject) => {
+      const body = {
+        "pay:logIn": {
+          request: {
+            username: username,
+            password: password
+          }
+        }
+      }
+
+      return this.createSoapRequest({ body: body })
+        .then(soapBody => {
+          const sessionId = soapBody['ns1:logInResponse'].logInResult.id;
+
+          return resolve({ sessionId: sessionId })
+        }).catch(err => {
+          reject(err)
+        })
+    })
+  }
+
+  creditInvoice({ sessionId, orderId, amount }) {
+    if (!sessionId) {
+      throw new Error('sessionId is required');
+    }
+
+    if (!this.config.signature) {
+      throw new Error('signature is required');
+    }
+
+    if (!orderId) {
+      throw new Error('orderId is required');
+    }
+
+    if (!amount) {
+      throw new Error('amount is required');
+    }
+
+    if (amount < 0.1 || amount > 99999) {
+      throw new Error('Invalid amount value. A minimum of ' +
+        '0.10 and a maximum of 99999 units are permitted ');
+    }
+
+    return new Promise((resolve, reject) => {
+      const body = {
+        "pay:credit": {
+          request: {
+            sessionId: sessionId,
+            sacId: this.config.signature,
+            orderId: orderId,
+            amount: amount
+          }
+        }
+      }
+
+      return this.createSoapRequest({ body: body })
+        .then(soapBody => {
+          const creditResult = soapBody['ns1:creditResponse'].creditResult;
+
+          return resolve(creditResult)
+        }).catch(err => {
+          reject(err)
+        })
+    })
   }
 
   handleGatewayResponse({ envKey, data } = {}) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,8 +23,8 @@ const REQUEST_ENDPOINTS = {
     [SANDBOX_MODE]: 'http://sandboxsecure.mobilpay.ro/card4'
   },
   SOAP_API: {
-    [SANDBOX_MODE]: 'http://sandboxsecure.mobilpay.ro/api/payment2/',
-    [LIVE_MODE]: 'https://secure.mobilpay.ro/api/payment2/'
+    [LIVE_MODE]: 'https://secure.mobilpay.ro/api/payment2/',
+    [SANDBOX_MODE]: 'http://sandboxsecure.mobilpay.ro/api/payment2/'
   },
 };
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,7 +21,11 @@ const REQUEST_ENDPOINTS = {
   [SERVICE_PREFILLED_CARD_DATA_PAYMENT] :{
     [LIVE_MODE]: 'https://secure.mobilpay.ro/card4',
     [SANDBOX_MODE]: 'http://sandboxsecure.mobilpay.ro/card4'
-  }
+  },
+  SOAP_API: {
+    [SANDBOX_MODE]: 'http://sandboxsecure.mobilpay.ro/api/payment2/',
+    [LIVE_MODE]: 'https://secure.mobilpay.ro/api/payment2/'
+  },
 };
 
 const ADDRESS_TYPE_COMPANY = 'company';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,8 +5,6 @@ const _ = require('lodash');
 const Promise = require('es6-promise').Promise;
 const crypto = require('crypto');
 const NodeRSA = require('node-rsa');
-const constants = require('./constants');
-const CardRequest = require('./request/CardRequest');
 
 module.exports.getUniqueId = getUniqueId;
 module.exports.encrypt = encrypt;


### PR DESCRIPTION
To return money back to customer, MobilPay provides a SOAP API.
The request (POST Request) needs to contain the following xml:
```xml
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pay="https://secure.mobilpay.ro/api/payment2/">
   <soapenv:Header/>
   <soapenv:Body>
      <pay:credit>
         <request>
            <!--You may enter the following 4 items in any order-->
            <sessionId>?</sessionId>
            <sacId>?</sacId>
            <orderId>?</orderId>
            <amount>?</amount>
         </request>
      </pay:credit>
   </soapenv:Body>
</soapenv:Envelope>
```

You can get the `session id` by doing another POST request with the following xml:
```xml
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pay="https://secure.mobilpay.ro/api/payment2/">
   <soapenv:Header/>
   <soapenv:Body>
      <pay:logIn>
         <request>
            <!--You may enter the following 2 items in any order-->
            <username>?</username>
            <password>?</password>
         </request>
      </pay:logIn>
   </soapenv:Body>
</soapenv:Envelope>
```
I have created the functionality to get the `session id` and return money to the customer.